### PR TITLE
chore: ignoring changes to task_definition to avoid overriding CD changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,6 +135,12 @@ resource "aws_ecs_service" "service" {
       Name = "${var.name_prefix}-ecs-tasks-sg"
     },
   )
+
+  lifecycle {
+    ignore_changes = [
+      task_definition
+    ]
+  }
 }
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
We use Github Actions to continuously deploy the application to ECS which results into updating the task definition. Whenever we apply the infra changes, terraform try to revert the definition which could even bring down the application. Ignore task definition in the life cycle events to safely apply infra changes without affecting deployed applications.